### PR TITLE
Double identifyEnvironmentAsync timeout

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -30,7 +30,7 @@ export function identifyEnvironmentAsync() {
     const timer = setTimeout(function() {
       childProcess.kill()
       reject(new Error('Process execution timed out'))
-    }, 2000)
+    }, 4000)
     childProcess.stdout.on('data', function(chunk) {
       stdout.push(chunk)
     })


### PR DESCRIPTION
I am developing an Atom plugin and trying to use this package to
determine an env when calling external processes.

My code looks like this:

``` js
const env = {};
consistentEnv.async()
  .then(computedEnv => { Object.assign(env, computedEnv); })
  .catch(e => { atom.notifications.addError(e); });
```

This seems to work maybe 50% of the time. The other ~50% I end up seeing
the following error logged in the console:

```
[consistent-env] Unable to determine environment Error: Unable to
determine environment
    at /path/to/node_modules/consistent-env/lib/helpers.js:71:11
```

If I change helpers.js:71 to throw the error it is catching

``` js
}).catch(function (error) {
  throw error;
  //throw new Error('Unable to determine environment');
});
```

then I get the following, more helpful message:

```
[consistent-env] Unable to determine environment Error: Process
execution timed out
    at /path/to/node_modules/consistent-env/lib/helpers.js:58:14
```

Increasing the timeout from 2000 to 4000 seems to make it much better on
my machine.

Fixes #9
