### PR TITLE
Throw caught error in identifyEnvironmentAsync

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -41,8 +41,8 @@ export function identifyEnvironmentAsync() {
     childProcess.on('error', function(error) {
       reject(error)
     })
-  }).catch(function() {
-    throw new Error('Unable to determine environment')
+  }).catch(function(error) {
+    throw error;
   })
 }
 


### PR DESCRIPTION
I am developing an Atom plugin and trying to use this package to
determine an env when calling external processes.

My code looks like this:

``` js
const env = {};
consistentEnv.async()
  .then(computedEnv => { Object.assign(env, computedEnv); })
  .catch(e => { atom.notifications.addError(e); });
```

This seems to work maybe 50% of the time. The other ~50% I end up seeing
the following error logged in the console:

```
[consistent-env] Unable to determine environment Error: Unable to
determine environment
    at /path/to/node_modules/consistent-env/lib/helpers.js:71:11
```

If I change helpers.js:71 to throw the error it is catching

``` js
}).catch(function (error) {
  throw error;
});
```

then I get the following, more helpful message:

```
[consistent-env] Unable to determine environment Error: Process
execution timed out
    at /path/to/node_modules/consistent-env/lib/helpers.js:58:14
```

I think this is a much more helpful error message that will make it
easier for future troubleshooting.

Addresses #9
