### PR TITLE
Separate the environment by \0 (Fixes #36)

### DIFF
--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -22,6 +22,11 @@ describe('Helpers', function() {
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
     })
+    it('works with spaces', async function() {
+      process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_WHITESPACE_TEST= text ')
+    })
     it('throws an error if it cant work', function() {
       process.env.SHELL = '/ha'
       expect(function() {
@@ -41,6 +46,11 @@ describe('Helpers', function() {
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
     })
+    it('works with spaces', async function() {
+      process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_WHITESPACE_TEST= text ')
+    })
     it('throws an error if it cant work', async function() {
       process.env.SHELL = '/ha'
       try {
@@ -54,15 +64,13 @@ describe('Helpers', function() {
   })
 
   describe('parse', function() {
-    it('parses properly ignoring spaces', function() {
-      const env = `
-        PATH=/usr/local/bin
-        HOME=/home/steel
-      `.split('\n')
+    it('parses properly with spaces', function() {
+      const env = ['PATH=/usr/local/bin', 'HOME=/home/steel', 'WHITESPACE_TEST= text ']
       const parsed = Helpers.parse(env)
-      expect(Object.keys(parsed)).toEqual(['PATH', 'HOME'])
+      expect(Object.keys(parsed)).toEqual(['PATH', 'HOME', 'WHITESPACE_TEST'])
       expect(parsed.PATH).toBe('/usr/local/bin')
       expect(parsed.HOME).toBe('/home/steel')
+      expect(parsed.WHITESPACE_TEST).toBe(' text ')
     })
   })
 

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -22,6 +22,11 @@ describe('Helpers', function() {
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
     })
+    it('works with newlines', async function() {
+      process.env.CONSISTENT_ENV_MULTILINE_TEST = 'line1\nline2'
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_MULTILINE_TEST=line1\nline2')
+    })
     it('works with spaces', async function() {
       process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
       const raw = await Helpers.identifyEnvironmentAsync()
@@ -45,6 +50,11 @@ describe('Helpers', function() {
       raw = raw.join('\n')
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
+    })
+    it('works with newlines', async function() {
+      process.env.CONSISTENT_ENV_MULTILINE_TEST = 'line1\nline2'
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_MULTILINE_TEST=line1\nline2')
     })
     it('works with spaces', async function() {
       process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,7 +20,7 @@ export const assign = Object.assign || function (target, source) {
 export function identifyEnvironment() {
   const { command, parameters, options } = getCommand()
   options.timeout = SPAWN_TIMEOUT
-  return spawnSync(command, parameters, options).stdout.toString().trim().split('\n')
+  return spawnSync(command, parameters, options).stdout.toString().split('\n')
 }
 
 export function identifyEnvironmentAsync() {
@@ -37,7 +37,7 @@ export function identifyEnvironmentAsync() {
     })
     childProcess.on('close', function() {
       clearTimeout(timer)
-      resolve(stdout.join('').trim().split('\n'))
+      resolve(stdout.join('').split('\n'))
     })
     childProcess.on('error', function(error) {
       reject(error)
@@ -50,8 +50,8 @@ export function parse(rawEnvironment: Array<string>): Object {
   for (const chunk of rawEnvironment) {
     const index = chunk.indexOf('=')
     if (index !== -1) {
-      const key = chunk.slice(0, index).trim()
-      const value = chunk.slice(index + 1).trim()
+      const key = chunk.slice(0, index)
+      const value = chunk.slice(index + 1)
       environment[key] = value
     }
   }


### PR DESCRIPTION
Output the environment from the shell separated by \0 instead of \n. This prevents confusion when the value of an environment variable contains newlines. (The value of an environment variable can't contain \0.)

The sh script is pretty ugly, but it should work everywhere. Unfortunately ``printenv --null`` is not available on many platforms.