### PR TITLE
Separate the environment by \0 (This time with python) (Fixes #36)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+### Project specific config ###
+language: generic
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+    - ATOM_LINT_WITH_BUNDLED_NODE="true"
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+os:
+  - linux
+  - osx
+
+dist: trusty
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+git:
+  depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - libsecret-1-dev
+    - fakeroot

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -27,6 +27,12 @@ describe('Helpers', function() {
       const raw = await Helpers.identifyEnvironmentAsync()
       expect(raw).toContain('CONSISTENT_ENV_MULTILINE_TEST=line1\nline2')
     })
+    it('works with variable assignments in values', async function() {
+      process.env.CONSISTENT_ENV_BOX_TEST = 'line\nCONSISTENT_ENV_BOX_FAIL=text'
+      let raw = await Helpers.identifyEnvironmentAsync()
+      raw = raw.map(e => e.split('=')[0])
+      expect(raw).not.toContain('CONSISTENT_ENV_BOX_FAIL')
+    })
     it('works with spaces', async function() {
       process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
       const raw = await Helpers.identifyEnvironmentAsync()
@@ -55,6 +61,12 @@ describe('Helpers', function() {
       process.env.CONSISTENT_ENV_MULTILINE_TEST = 'line1\nline2'
       const raw = await Helpers.identifyEnvironmentAsync()
       expect(raw).toContain('CONSISTENT_ENV_MULTILINE_TEST=line1\nline2')
+    })
+    it('works with variable assignments in values', async function() {
+      process.env.CONSISTENT_ENV_BOX_TEST = 'line\nCONSISTENT_ENV_BOX_FAIL=text'
+      let raw = await Helpers.identifyEnvironmentAsync()
+      raw = raw.map(e => e.split('=')[0])
+      expect(raw).not.toContain('CONSISTENT_ENV_BOX_FAIL')
     })
     it('works with spaces', async function() {
       process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -22,6 +22,11 @@ describe('Helpers', function() {
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
     })
+    it('works with spaces', async function() {
+      process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_WHITESPACE_TEST= text ')
+    })
     it('throws an error if it cant work', function() {
       process.env.SHELL = '/ha'
       expect(function() {
@@ -41,6 +46,11 @@ describe('Helpers', function() {
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
     })
+    it('works with spaces', async function() {
+      process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_WHITESPACE_TEST= text ')
+    })
     it('throws an error if it cant work', async function() {
       process.env.SHELL = '/ha'
       try {
@@ -54,15 +64,13 @@ describe('Helpers', function() {
   })
 
   describe('parse', function() {
-    it('parses properly ignoring spaces', function() {
-      const env = `
-        PATH=/usr/local/bin
-        HOME=/home/steel
-      `.split('\n')
+    it('parses properly with spaces', function() {
+      const env = ['PATH=/usr/local/bin', 'HOME=/home/steel', 'WHITESPACE_TEST= text ']
       const parsed = Helpers.parse(env)
-      expect(Object.keys(parsed)).toEqual(['PATH', 'HOME'])
+      expect(Object.keys(parsed)).toEqual(['PATH', 'HOME', 'WHITESPACE_TEST'])
       expect(parsed.PATH).toBe('/usr/local/bin')
       expect(parsed.HOME).toBe('/home/steel')
+      expect(parsed.WHITESPACE_TEST).toBe(' text ')
     })
   })
 

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -22,6 +22,11 @@ describe('Helpers', function() {
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
     })
+    it('works with newlines', async function() {
+      process.env.CONSISTENT_ENV_MULTILINE_TEST = 'line1\nline2'
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_MULTILINE_TEST=line1\nline2')
+    })
     it('works with spaces', async function() {
       process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '
       const raw = await Helpers.identifyEnvironmentAsync()
@@ -45,6 +50,11 @@ describe('Helpers', function() {
       raw = raw.join('\n')
       expect(raw).toContain('PATH=')
       expect(raw).toContain('SHELL=')
+    })
+    it('works with newlines', async function() {
+      process.env.CONSISTENT_ENV_MULTILINE_TEST = 'line1\nline2'
+      const raw = await Helpers.identifyEnvironmentAsync()
+      expect(raw).toContain('CONSISTENT_ENV_MULTILINE_TEST=line1\nline2')
     })
     it('works with spaces', async function() {
       process.env.CONSISTENT_ENV_WHITESPACE_TEST = ' text '

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -88,7 +88,9 @@ export function applySugar(environment: Object) {
 
 export function getCommand(): { command: string, options: Object, parameters: Array<string> } {
   // Print the environment separated by \0
-  const shScript = ('python -c "import os;print(\\"\\0\\".join(map(\\"=\\".join, dict(os.environ).items()))+\\"\\0\\")"||' +
+  const pyScript = 'import os;print(\\"\\0\\".join(map(\\"=\\".join, dict(os.environ).items()))+\\"\\0\\")'
+  const shScript = ('python -c "' + pyScript + '"||' +
+                    'python3 -c "' + pyScript + '"||' +
                     // If python is not available, fallback to a POSIX compatible
                     // way of retrieving the environment separated by \0.
                     'env|' +

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -87,8 +87,11 @@ export function applySugar(environment: Object) {
 }
 
 export function getCommand(): { command: string, options: Object, parameters: Array<string> } {
-  // Print the environment separated by \0 in a POSIX compatible (!) way.
-  const shScript = ('env|' +
+  // Print the environment separated by \0
+  const shScript = ('python -c "import os;print(\\"\\0\\".join(map(\\"=\\".join, dict(os.environ).items()))+\\"\\0\\")"||' +
+                    // If python is not available, fallback to a POSIX compatible
+                    // way of retrieving the environment separated by \0.
+                    'env|' +
                     // Find all names of potential environment variables.
                     // This also returns variable assignments that are in the value
                     // of another environment variable.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,7 +20,7 @@ export const assign = Object.assign || function (target, source) {
 export function identifyEnvironment() {
   const { command, parameters, options } = getCommand()
   options.timeout = SPAWN_TIMEOUT
-  return spawnSync(command, parameters, options).stdout.toString().trim().split('\n')
+  return spawnSync(command, parameters, options).stdout.toString().split('\n')
 }
 
 export function identifyEnvironmentAsync() {
@@ -37,7 +37,7 @@ export function identifyEnvironmentAsync() {
     })
     childProcess.on('close', function() {
       clearTimeout(timer)
-      resolve(stdout.join('').trim().split('\n'))
+      resolve(stdout.join('').split('\n'))
     })
     childProcess.on('error', function(error) {
       reject(error)
@@ -50,8 +50,8 @@ export function parse(rawEnvironment: Array<string>): Object {
   for (const chunk of rawEnvironment) {
     const index = chunk.indexOf('=')
     if (index !== -1) {
-      const key = chunk.slice(0, index).trim()
-      const value = chunk.slice(index + 1).trim()
+      const key = chunk.slice(0, index)
+      const value = chunk.slice(index + 1)
       environment[key] = value
     }
   }


### PR DESCRIPTION
Basically the same as #36 but it tries to use python for variable extraction first. It still falls back to the sh script, if python is not available. I added an explanation to the sh script and more tests.